### PR TITLE
Scaffold: initial docs split, interfaces, project context

### DIFF
--- a/.github/COPILOT_INSTRUCTIONS.md
+++ b/.github/COPILOT_INSTRUCTIONS.md
@@ -1,0 +1,16 @@
+# Repo-Specific Copilot Instructions
+
+Primary Goals:
+- Implement Blazor Server ATC training simulator per docs/.
+
+Guidelines:
+1. Reuse service interfaces in `docs/backend/service-interfaces.cs` until proper projects exist.
+2. Generate strongly-typed records for JSON schemas (InstructorVerdict, AtcReply) and ensure System.Text.Json attributes if needed.
+3. Always add CancellationToken parameters.
+4. Keep methods small; prefer pure helpers for scoring & state reduction.
+5. For new prompts, update docs/prompts and reference them in code comments.
+6. Avoid leaking API keys or returning raw exceptions to clients.
+7. When adding external libraries, update README and justify.
+
+Output Style:
+- For model outputs requiring JSON: ensure exact schema compliance.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,22 @@
+---
+name: Bug report
+about: Create a report to help us improve
+labels: bug
+---
+
+## Describe the bug
+
+## Steps To Reproduce
+1. 
+2. 
+
+## Expected Behavior
+
+## Actual Behavior / Logs
+
+## Environment
+- OS:
+- Browser:
+- .NET Version:
+
+## Additional Context

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name: Feature request
+aout: Suggest an idea for this project
+labels: enhancement
+---
+
+## Summary
+
+## Motivation / Problem
+
+## Proposed Solution
+
+## Alternatives Considered
+
+## Additional Context

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Summary
+
+## Changes
+- 
+
+## Testing
+- [ ] Unit tests added/updated
+- [ ] Manual turn loop smoke tested
+
+## Screenshots / Recordings (if UI)
+
+## Checklist
+- [ ] Docs updated (if needed)
+- [ ] No secrets committed
+- [ ] JSON outputs validated (if prompts/schema changed)

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+bin/
+obj/
+.vscode/
+.idea/
+app_data/
+*.db
+*.db-shm
+*.db-wal
+publish/
+.env

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing
+
+1. Fork and branch from `main` (feature/short-desc).
+2. Keep changes atomic; update related docs if contracts change.
+3. Run formatting (`dotnet format`) and tests before PR.
+4. For prompt changes: explain rationale and provide before/after sample.
+5. Do not include real API keys or proprietary frequency data in commits.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,1 @@
+TBD - Select appropriate license (e.g., Apache-2.0 or MIT) before public release.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # trainmeatc
-ATC radio comms training simulator MVP (voice-only) - Blazor Server + OpenAI
+
+ATC radio communication training simulator MVP (voice-only) built with Blazor Server, SQLite, and OpenAI (STT, LLM, TTS). This repo contains docs, backend, and frontend segments.
+
+## Segments
+- `docs/` high-level design, architecture, prompts, roadmap
+- `backend/` Blazor Server solution, services, data layer, SignalR
+- `frontend/` UI components (Blazor pages/components), audio capture scripts
+
+## Status
+Scaffold in progress.
+
+## License
+TBD

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,13 @@
+# Backend Segment
+
+Blazor Server app (monolith) providing:
+- REST endpoints for STT, Instructor, ATC, TTS, Sessions, State
+- SignalR hub for realtime updates
+- EF Core (SQLite) data layer
+- OpenAI service integrations (STT, Responses, TTS)
+
+Planned projects:
+- `PilotSim.Server` (main Host)
+- `PilotSim.Core` (domain models + services interfaces)
+- `PilotSim.Data` (EF Core DbContext, migrations)
+- `PilotSim.Tests` (unit tests)

--- a/docs/COPILOT_INSTRUCTIONS.md
+++ b/docs/COPILOT_INSTRUCTIONS.md
@@ -1,0 +1,15 @@
+# GitHub Copilot Instructions
+
+Provide focused assistance for this project:
+
+- Stack: .NET 9 (or 8 if 9 not GA yet), Blazor Server, C#, SQLite (via EF Core), SignalR, OpenAI SDK.
+- Follow existing interfaces and prompts in `docs/prompts`.
+- Prefer streaming patterns for STT and model responses.
+- Do not expose `OPENAI_API_KEY` to client code; only server-side services may access it.
+- Generate minimal, testable slices: add service interface, then stub implementation, then wire into DI and a razor page.
+- Keep transmissions and prompt outputs JSON-valid when required.
+- Use cancellation tokens in all async service calls.
+- When adding new airports or frequencies, place authoritative source comment referencing AIP (do not hardcode speculative data).
+- For EF Core migrations: name them with timestamp + concise purpose, e.g., `20250927_Init`.
+
+When unsure: search the `docs/` directory before generating new patterns to avoid drift.

--- a/docs/COPILOT_PROJECT_CONTEXT.md
+++ b/docs/COPILOT_PROJECT_CONTEXT.md
@@ -1,0 +1,18 @@
+# Copilot Project Context Summary
+
+Goal: Voice-only ATC comms training simulator (Australia focus) with Instructor + ATC bots, using OpenAI for STT, LLM logic, and TTS.
+
+Key Directories:
+- docs/prompts -> authoritative prompts (keep in sync)
+- docs/db/schema.sql -> SQLite schema baseline
+- backend/ -> Blazor Server solution (to be scaffolded)
+- frontend/ -> UI Razor components (within same server project, but logical separation)
+
+Service Interfaces (planned): ISttService, IInstructorService, IAtcService, ITtsService.
+
+Non-negotiables:
+- No API key leakage
+- Structured JSON outputs validated
+- Australian phraseology adherence
+
+When generating code: ensure async, cancellation support, small cohesive methods, DI-friendly.

--- a/docs/DISCLAIMER.md
+++ b/docs/DISCLAIMER.md
@@ -1,0 +1,3 @@
+# Disclaimer
+
+Training aid only. Do not use for real-world aviation decision-making. Always refer to current, official AIP, ERSA, and regulatory guidance.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+# Documentation Index
+
+- `mvp-spec/` Original MVP build spec split into domain-focused docs.
+- `prompts/` System and model prompt packs.
+- `architecture/` Diagrams and service contracts.
+- `scenarios/` Scenario JSON DSL examples.
+- `db/` Schema and migrations.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,31 @@
+# Roadmap (Initial)
+
+## Milestone 0 - Scaffold
+- Repo + docs split (DONE)
+- Service interfaces placeholder (DONE)
+- Blazor Server solution scaffold
+- EF Core DbContext + initial migration
+
+## Milestone 1 - Core Loop
+- STT endpoint + partial transcript streaming
+- Instructor structured output + retry gating
+- ATC response + state progression
+- TTS synthesis + playback
+
+## Milestone 2 - Debrief & Scoring
+- Score aggregation display
+- Timeline with audio + transcripts
+
+## Milestone 3 - Hardening
+- Rate limiting, size limits
+- Caching & performance tuning
+- Docker build + compose
+
+## Milestone 4 - Enhancements
+- Background traffic
+- Readback fuzzy matcher
+- METAR stub
+- Replay with commentary
+
+## Stretch
+- Realtime WebRTC integration

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Notes
+
+- API key isolation: only server environment variable `OPENAI_API_KEY`.
+- Planned rate limits: STT (20 req/min/IP), ATC (15 req/min/IP).
+- Audio upload size max: 2.5MB per chunk.
+- Purge: implement /api/admin/purge (auth TBD) to delete old audio + sessions.
+- No dynamic frequency generation; ensure prompts never request unseeded frequencies.

--- a/docs/architecture/component-boundaries.md
+++ b/docs/architecture/component-boundaries.md
@@ -1,0 +1,7 @@
+# Component Boundaries
+
+- Web/UI: Razor components only orchestrate user input and display.
+- Services: Wrap external calls (OpenAI) behind interfaces for testability.
+- Data Layer: EF Core context + migration scripts, repository helpers.
+- State Reducer: Pure functions to apply ATC next_state patches.
+- Scoring Engine: Consumes InstructorVerdict + scenario rubric.

--- a/docs/architecture/configuration-keys.md
+++ b/docs/architecture/configuration-keys.md
@@ -1,0 +1,9 @@
+# Configuration Keys
+
+| Key | Source | Notes |
+|-----|--------|-------|
+| OPENAI_API_KEY | Environment | Required for all OpenAI calls |
+| ConnectionStrings:SimDb | appsettings.json / env | SQLite path (e.g., Data Source=app_data/sim.db) |
+| RateLimits:SttPerMinute | appsettings.json | Default 20 |
+| RateLimits:AtcPerMinute | appsettings.json | Default 15 |
+| Logging:Level | appsettings.json | Serilog minimum level |

--- a/docs/architecture/diagrams-placeholder.md
+++ b/docs/architecture/diagrams-placeholder.md
@@ -1,0 +1,3 @@
+# Diagrams Placeholder
+
+Add Mermaid or external diagram exports (sequence, component) in future commits.

--- a/docs/architecture/error-handling-patterns.md
+++ b/docs/architecture/error-handling-patterns.md
@@ -1,0 +1,17 @@
+# Error Handling Patterns
+
+Controller Pattern:
+```csharp
+try {
+  // service call
+} catch (RateLimitException ex) {
+  return TooManyRequests(ex.RetryAfter);
+} catch (ValidationException ex) {
+  return BadRequest(new { code = ex.Code, ex.Message });
+} catch (UpstreamException ex) {
+  _logger.LogWarning(ex, "Upstream failure");
+  return StatusCode(502, new { code = "OPENAI_UPSTREAM" });
+}
+```
+
+Do not expose stack traces to clients (except in Development environment).

--- a/docs/architecture/high-level.md
+++ b/docs/architecture/high-level.md
@@ -1,0 +1,10 @@
+# High-Level Architecture
+
+Blazor Server Host
+- Razor Pages + Components
+- SignalR Hub (LiveHub)
+- REST Controllers (STT, Instructor, ATC, TTS, Sessions, State)
+- EF Core (SQLite) + Repositories
+- OpenAI Integration Services (STT, Responses, TTS)
+
+Clients connect via websocket for hub events; audio upload via REST.

--- a/docs/architecture/performance-tuning.md
+++ b/docs/architecture/performance-tuning.md
@@ -1,0 +1,6 @@
+# Performance Tuning Notes
+
+- Use HttpClientFactory for OpenAI calls to avoid socket exhaustion.
+- Enable Response Compression for SignalR JSON payloads.
+- Consider binary protocol for transcripts (MessagePack) later.
+- Warm up: pre-load first model call on startup to reduce user-perceived latency.

--- a/docs/architecture/sequence-turn-loop.md
+++ b/docs/architecture/sequence-turn-loop.md
@@ -1,0 +1,12 @@
+# Turn Loop Sequence (Simplified)
+
+1. User audio chunk -> /api/stt
+2. STT partial -> SignalR `partialTranscript`
+3. Final STT -> Instructor request
+4. Instructor verdict -> SignalR `instructorVerdict`
+5. If blocked: UI shows Retry
+6. If pass: ATC request
+7. ATC reply -> SignalR `atcTransmission`
+8. TTS synth -> file saved
+9. SignalR `ttsReady` -> client plays
+10. Score update -> `scoreTick`

--- a/docs/architecture/signalr-events.md
+++ b/docs/architecture/signalr-events.md
@@ -1,0 +1,9 @@
+# SignalR Events
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| partialTranscript | { text, isFinal? } | Streaming STT updates |
+| instructorVerdict | InstructorVerdict JSON | Verdict after transcript processed |
+| atcTransmission | { transmission, expected_readback[] } | ATC reply |
+| ttsReady | { url } | Audio file ready for playback |
+| scoreTick | { scoreTotal, delta } | Score update |

--- a/docs/architecture/telemetry-events.md
+++ b/docs/architecture/telemetry-events.md
@@ -1,0 +1,9 @@
+# Telemetry Events (Planned)
+
+| Event | Properties |
+|-------|------------|
+| stt_chunk_ms | duration_ms, bytes |
+| instructor_latency_ms | duration_ms, normalized, score_delta |
+| atc_latency_ms | duration_ms |
+| tts_latency_ms | duration_ms, text_length |
+| turn_completed | turn_index, score_total |

--- a/docs/backend/di-notes.md
+++ b/docs/backend/di-notes.md
@@ -1,0 +1,26 @@
+# Dependency Injection Notes
+
+Planned registrations (example):
+
+```csharp
+builder.Services.AddSingleton<ISttService, OpenAiSttService>();
+builder.Services.AddScoped<IInstructorService, OpenAiInstructorService>();
+builder.Services.AddScoped<IAtcService, OpenAiAtcService>();
+builder.Services.AddSingleton<ITtsService, OpenAiTtsService>();
+```
+
+DbContext (once created):
+```csharp
+builder.Services.AddDbContext<SimDbContext>(o => o.UseSqlite(builder.Configuration.GetConnectionString("SimDb")));
+```
+
+SignalR:
+```csharp
+builder.Services.AddSignalR();
+```
+
+Configuration Keys:
+- OPENAI_API_KEY (env var) -> injected via `IConfiguration`.
+
+Resilience:
+- Consider Polly for transient retries around OpenAI calls.

--- a/docs/backend/docker-notes.md
+++ b/docs/backend/docker-notes.md
@@ -1,0 +1,12 @@
+# Docker Notes
+
+Publish Flow:
+1. `dotnet publish -c Release -o publish`
+2. Build image from Dockerfile (runtime image only) - multi-stage build to be added later.
+
+Volumes:
+- `/app/app_data` mounted for audio + sqlite db.
+
+Future:
+- Add health endpoint `/health` and use Docker HEALTHCHECK.
+- Multi-stage (sdk -> runtime) to shrink image.

--- a/docs/backend/error-codes.md
+++ b/docs/backend/error-codes.md
@@ -1,0 +1,11 @@
+# Error Codes (Planned)
+
+| Code | HTTP | Meaning |
+|------|------|---------|
+| STT_RATE_LIMIT | 429 | Too many STT requests |
+| ATC_RATE_LIMIT | 429 | Too many ATC requests |
+| AUDIO_TOO_LARGE | 413 | Uploaded audio chunk exceeds max size |
+| JSON_SCHEMA_FAIL | 500 | Model output invalid after repair attempts |
+| OPENAI_UPSTREAM | 502 | Upstream OpenAI temporary failure |
+| SESSION_NOT_FOUND | 404 | Session id invalid |
+| STATE_BLOCKED | 409 | Action blocked due to Instructor verdict |

--- a/docs/backend/fuzzy-readback-matcher-notes.md
+++ b/docs/backend/fuzzy-readback-matcher-notes.md
@@ -1,0 +1,13 @@
+# Fuzzy Readback Matcher (Future Improvement)
+
+Approach:
+- Tokenize expected_readback items and user transcript.
+- Use normalized Levenshtein or Sørensen-Dice coefficient for similarity.
+- Thresholds:
+  - Critical if <0.6 similarity on mandatory items (runway, QNH, altitude, callsign)
+  - Minor warning if 0.6..0.8
+
+Potential libs:
+- Implement small custom (avoid heavy deps) or use `FuzzySharp` if acceptable.
+
+Note: Accent / STT errors - allow phonetic approximations (kilo vs kelo) by custom replacement map before compare.

--- a/docs/backend/latency-targets.md
+++ b/docs/backend/latency-targets.md
@@ -1,0 +1,15 @@
+# Latency Targets
+
+Per 5s speech chunk:
+- STT: <600ms
+- Instructor: <400ms
+- ATC: <600ms
+- TTS: <400ms
+
+Streaming Goals:
+- partialTranscript events >= 2 Hz
+
+Mitigations:
+- Parallelize Instructor request prep while final STT words arriving.
+- Cache frequent TTS phrases (greetings, acknowledgements).
+- Use seeded randomness to avoid re-generation drift causing cache misses.

--- a/docs/backend/logging-observability.md
+++ b/docs/backend/logging-observability.md
@@ -1,0 +1,6 @@
+# Logging & Observability
+
+- Use Serilog (console + rolling file) excluding sensitive data.
+- Correlate per-session logs with session_id.
+- Log key events: STT chunk received, Instructor verdict summary, ATC transmission JSON, TTS synth success, errors.
+- Metrics (future): latency histograms per stage (STT, Instructor, ATC, TTS) exported via /metrics (Prometheus format).

--- a/docs/backend/openai-integration.md
+++ b/docs/backend/openai-integration.md
@@ -1,0 +1,22 @@
+# OpenAI Integration Notes
+
+Services:
+- STT: Audio Transcriptions (gpt-4o-mini-transcribe primary, whisper-1 fallback)
+- Instructor: Responses API + structured output schema (see prompts)
+- ATC: Responses API + structured output schema
+- TTS: Speech API (gpt-4o-mini-tts)
+
+General guidelines:
+- Always pass shared system preamble.
+- Use temperature: Instructor 0.3, ATC 0.4; set seed for reproducibility.
+- Validate JSON against schema; retry once on failure with a repair prompt.
+- Stream partial tokens where possible; push partialTranscript events.
+- Do not log raw API key.
+
+Error handling:
+- Network / 5xx: exponential backoff (250ms, 500ms, 1s) max 3 attempts.
+- JSON validation failure: attempt structured repair (include original response in a tool call repair message) then fallback to safe block.
+
+Security:
+- Only server holds OPENAI_API_KEY (IConfiguration / environment variable).
+- If/when realtime added: server mints ephemeral tokens (short TTL) using official endpoint.

--- a/docs/backend/openai-repair-strategy.md
+++ b/docs/backend/openai-repair-strategy.md
@@ -1,0 +1,9 @@
+# Structured Output Repair Strategy
+
+When a Responses API call (Instructor or ATC) returns invalid JSON:
+1. Attempt to parse; if failure, capture raw text.
+2. Issue a secondary call with system prompt prefix: `Return ONLY valid JSON for the provided schema. Original response: <<<...>>>`.
+3. If second attempt still invalid, fallback:
+   - Instructor: treat as critical block (block_reason = phraseology) with generic improvement message.
+   - ATC: return hold_short true with transmission: "Standby.".
+4. Log incident (without key) for diagnostics.

--- a/docs/backend/rate-limiting-strategy.md
+++ b/docs/backend/rate-limiting-strategy.md
@@ -1,0 +1,12 @@
+# Rate Limiting Strategy
+
+Endpoints:
+- /api/stt : token bucket 20 req/min/IP
+- /api/atc : token bucket 15 req/min/IP
+- /api/instructor : implicitly tied to /api/stt (could share bucket)
+
+Implementation Options:
+- ASP.NET middleware + MemoryCache sliding counters
+- Or `AspNetCoreRateLimit` NuGet
+
+Responses on limit exceed: 429 with `Retry-After` header.

--- a/docs/backend/scoring-algorithm-notes.md
+++ b/docs/backend/scoring-algorithm-notes.md
@@ -1,0 +1,15 @@
+# Scoring Algorithm Notes
+
+Base: score_total starts at 0.
+- Add Instructor verdict ScoreDelta on each accepted turn.
+- Critical errors -> negative deltas and block progression.
+
+Metrics:
+- average_normalized = mean of normalized values for accepted turns
+- retries = count of blocked turns preceding acceptance
+- total_time = session end - start
+
+Outcome resolution:
+- Completed when scenario end condition reached (e.g., join downwind acknowledged)
+- Timeout after configurable idle threshold (e.g., 90s no user audio)
+- safety_block if repeated safety critical failures (>=3) without recovery

--- a/docs/backend/seed-data-notes.md
+++ b/docs/backend/seed-data-notes.md
@@ -1,0 +1,12 @@
+# Seed Data Notes
+
+Airports (placeholders - fetch authoritative frequencies before production):
+- YBBN Brisbane
+- YSSY Sydney
+- YMML Melbourne
+- YPAD Adelaide
+
+Seeding Process:
+1. On first run, detect empty airport table.
+2. Insert rows with placeholder frequencies (NULL) and comment referencing AIP requirement.
+3. Provide admin utility to update with actual frequencies (DO NOT bake into source without citation).

--- a/docs/backend/service-interfaces.cs
+++ b/docs/backend/service-interfaces.cs
@@ -1,0 +1,39 @@
+// Placeholder for early service interface compilation (will move into PilotSim.Core project once scaffolded)
+namespace PilotSim.Core;
+
+public record SttWord(string Text, double Start, double End);
+public record SttResult(string Text, IReadOnlyList<SttWord> Words);
+
+public enum Difficulty { Basic, Medium, Advanced }
+public record Load(float TrafficDensity, float Clarity, string ControllerPersona, string RfQuality);
+
+public interface ISttService {
+    Task<SttResult> TranscribeAsync(Stream wavStream, string biasPrompt, CancellationToken cancellationToken);
+}
+
+public record InstructorVerdict(
+    IReadOnlyList<string> Critical,
+    IReadOnlyList<string> Improvements,
+    string? ExemplarReadback,
+    double Normalized,
+    int ScoreDelta,
+    string BlockReason);
+
+public interface IInstructorService {
+    Task<InstructorVerdict> ScoreAsync(string transcript, object state, Difficulty difficulty, CancellationToken cancellationToken);
+}
+
+public record AtcReply(
+    string Transmission,
+    IReadOnlyList<string> ExpectedReadback,
+    object? NextState,
+    bool? HoldShort,
+    string? TtsTone);
+
+public interface IAtcService {
+    Task<AtcReply> NextAsync(string transcript, object state, Difficulty difficulty, Load load, CancellationToken cancellationToken);
+}
+
+public interface ITtsService {
+    Task<string> SynthesizeAsync(string text, string voice, string style, CancellationToken cancellationToken);
+}

--- a/docs/backend/state-reducer-notes.md
+++ b/docs/backend/state-reducer-notes.md
@@ -1,0 +1,17 @@
+# State Reducer Notes
+
+The ATC reply includes `next_state` patch fields. Apply reducer logic:
+
+Inputs:
+- Prior state object (immutable snapshot)
+- AtcReply.NextState (partial)
+
+Process:
+1. Validate altitude/heading ranges (altitude 0..12000 ft for VFR training scope; heading 0..359).
+2. Merge non-null fields.
+3. Append sequencing / approach changes to a state log for Debrief timeline.
+4. Persist serialized JSON with turn record.
+
+Edge Cases:
+- hold_short true: do not mutate state except maybe a retry counter.
+- missing fields: keep previous values.

--- a/docs/backend/testing-strategy.md
+++ b/docs/backend/testing-strategy.md
@@ -1,0 +1,21 @@
+# Testing Strategy
+
+Test Layers:
+- Unit: service helpers (e.g., JSON schema validation, scoring normalizer)
+- Integration: OpenAI call wrappers (behind interfaces) using test doubles
+- Functional: Turn loop (in-memory DB + mocked OpenAI) ensuring retry gating
+
+Key Cases:
+1. Missing QNH -> Instructor critical -> block ATC
+2. Wrong runway readback -> critical list populated
+3. Persona fast + noisy RF -> still returns intelligible ATC transmission
+4. Handoff only when next_state indicates readiness
+5. Silence / timeout -> outcome set to timeout
+
+Tooling:
+- xUnit
+- FluentAssertions
+- Bogus (for generating sample transcripts) if needed
+
+Determinism:
+- Use seeded values for any randomized scenario elements.

--- a/docs/db/schema.sql
+++ b/docs/db/schema.sql
@@ -1,0 +1,64 @@
+-- Core schema (initial cut; see comprehensive spec for details)
+create table if not exists airport (
+  icao text primary key,
+  name text not null,
+  lat real,
+  lon real,
+  atis_freq text,
+  tower_freq text,
+  ground_freq text,
+  app_freq text
+);
+
+create table if not exists runway (
+  id integer primary key autoincrement,
+  airport_icao text not null,
+  ident text not null,
+  magnetic_heading integer,
+  length_m integer,
+  ils boolean,
+  foreign key(airport_icao) references airport(icao)
+);
+
+create table if not exists scenario (
+  id integer primary key autoincrement,
+  name text,
+  airport_icao text,
+  kind text,
+  difficulty text,
+  seed integer,
+  initial_state_json text,
+  rubric_json text
+);
+
+create table if not exists session (
+  id integer primary key autoincrement,
+  user_id integer,
+  scenario_id integer,
+  started_utc text,
+  ended_utc text,
+  difficulty text,
+  parameters_json text,
+  score_total integer default 0,
+  outcome text
+);
+
+create table if not exists turn (
+  id integer primary key autoincrement,
+  session_id integer,
+  idx integer,
+  user_audio_path text,
+  user_transcript text,
+  instructor_json text,
+  atc_json text,
+  tts_audio_path text,
+  verdict text
+);
+
+create table if not exists metric (
+  id integer primary key autoincrement,
+  session_id integer,
+  k text,
+  v real,
+  t_utc text
+);

--- a/docs/frontend/audio-capture-notes.md
+++ b/docs/frontend/audio-capture-notes.md
@@ -1,0 +1,7 @@
+# Audio Capture & Playback Notes
+
+- Use JS interop to access MediaDevices.getUserMedia with 16kHz mono processing through OfflineAudioContext resample if needed.
+- Chunking: 1.5s PCM buffers encoded to WAV (PCM 16-bit LE) -> base64 -> POST /api/stt.
+- Provide visual level meter (RMS) and disable send while retry loop active.
+- Playback: HTMLAudioElement for TTS mp3/wav sources from /app_data/audio (served via static file mapping).
+- Optional RF quality simulation: apply BiquadFilter (high-pass ~300Hz) + subtle pink noise gain 0.02 for 'noisy'.

--- a/docs/frontend/audio-fx-notes.md
+++ b/docs/frontend/audio-fx-notes.md
@@ -1,0 +1,8 @@
+# Audio FX Notes (Optional)
+
+For rf_quality=noisy:
+- Apply high-pass filter at 300Hz (Q ~0.7) and low-pass at 3kHz
+- Inject pink noise at low gain (0.02 to 0.04)
+- Optional slight compression (ratio 2:1) to mimic radio dynamics
+
+Ensure intelligibility score (subjective) remains high; avoid over-degradation.

--- a/docs/frontend/component-inventory.md
+++ b/docs/frontend/component-inventory.md
@@ -1,0 +1,20 @@
+# Component Inventory (Planned)
+
+- Pages:
+  - `Pages/Index.razor` (Home / Disclaimer accept)
+  - `Pages/ScenarioSelect.razor`
+  - `Pages/LiveSim.razor`
+  - `Pages/Debrief.razor`
+- Components:
+  - `Components/MicCapture.razor`
+  - `Components/TranscriptPane.razor`
+  - `Components/ATCPanel.razor`
+  - `Components/ScoreStrip.razor`
+  - `Components/RetryBar.razor`
+  - `Components/AudioPlayer.razor`
+- JS Interop:
+  - `wwwroot/js/audioCapture.js` (start/stop, chunk encode, level meter)
+
+State Flow Notes:
+- LiveSim orchestrates turn loop via injected services + SignalR callbacks.
+- Retry gating: Instructor verdict with block reason prevents ATC request until cleared.

--- a/docs/frontend/ux-flow.md
+++ b/docs/frontend/ux-flow.md
@@ -1,0 +1,15 @@
+# UX Flow (High-Level)
+
+1. Home: Accept disclaimer -> proceed.
+2. Scenario Select: choose airport, difficulty, load sliders.
+3. LiveSim:
+   - MicCapture panel (push-to-talk or auto VOX future option)
+   - Transcript pane streaming text
+   - Retry bar (visible when Instructor blocks)
+   - ATC panel with last transmission + play
+   - Score strip animation for deltas
+4. Debrief:
+   - Timeline of turns (pilot transcript, instructor verdict summary, ATC transmission)
+   - Audio playback list
+   - Metrics: avg normalized, retries count, total time
+   - Study links (AIP/CASA)

--- a/docs/mvp-spec/00-master-spec-link.md
+++ b/docs/mvp-spec/00-master-spec-link.md
@@ -1,0 +1,3 @@
+# Master Spec Reference
+
+The original unified MVP spec content has been segmented across the `mvp-spec` files and `prompts` directory. For any section not yet expanded, refer back to the source planning document provided at project inception.

--- a/docs/mvp-spec/01-mvp-scope.md
+++ b/docs/mvp-spec/01-mvp-scope.md
@@ -1,0 +1,13 @@
+# 1. MVP Scope
+
+(Extracted from original spec) 
+
+1. Voice-only V1.
+2. Four hard-coded airports: YBBN, YSSY, YMML, YPAD.
+3. Single-player only.
+4. Two bots per turn: Instructor -> ATC.
+5. Difficulty levels: basic | medium | advanced.
+6. Adjustable load parameters: traffic density, clarity, controller persona.
+7. SQLite persistence.
+8. Blazor Server (monolith) for low latency.
+9. OpenAI for STT, LLM (Instructor + ATC), and TTS.

--- a/docs/mvp-spec/02-architecture.md
+++ b/docs/mvp-spec/02-architecture.md
@@ -1,0 +1,7 @@
+# 2. Architecture (Monolith)
+
+UI: Blazor Server (.NET 8/9) with WebAudio capture + audio playback.
+Realtime: SignalR hub for partial transcripts, scoring deltas, TTS stream events.
+LLM Services: STT, Instructor, ATC, TTS via OpenAI APIs. Realtime (WebRTC) optional later.
+DB: SQLite (WAL mode). Audio blob storage on disk under `/app_data/audio`.
+Optional future: Realtime API (ephemeral tokens) for sub-300ms loop.

--- a/docs/mvp-spec/03-data-model-and-api.md
+++ b/docs/mvp-spec/03-data-model-and-api.md
@@ -1,0 +1,12 @@
+# 3. Data Model & API Surface
+
+Includes SQLite schema (see `../db/schema.sql`) and REST + SignalR endpoints.
+
+API (internal):
+- POST /api/stt
+- POST /api/instructor
+- POST /api/atc
+- POST /api/tts
+- POST /api/session (start/end semantics)
+- GET /api/state/{sessionId}
+SignalR Hub: /hubs/live with events: partialTranscript, instructorVerdict, atcTransmission, ttsReady, scoreTick.

--- a/docs/mvp-spec/04-turn-loop-and-difficulty.md
+++ b/docs/mvp-spec/04-turn-loop-and-difficulty.md
@@ -1,0 +1,4 @@
+# 4. Turn Loop & Difficulty
+
+FSM Sequence: User speaks -> STT -> Instructor -> (retry? or ATC) -> TTS -> log.
+Latency targets and difficulty / load parameters as per original spec.

--- a/docs/mvp-spec/05-models-prompts-scoring.md
+++ b/docs/mvp-spec/05-models-prompts-scoring.md
@@ -1,0 +1,4 @@
+# 5. Models, Prompts & Scoring
+
+Models: STT gpt-4o-mini-transcribe (whisper-1 fallback), LLM gpt-4o / gpt-4.1, TTS gpt-4o-mini-tts. Structured outputs for Instructor & ATC.
+Scoring: normalized 0..1, scoreDelta aggregation, critical error gating.

--- a/docs/mvp-spec/06-docker-security-compliance.md
+++ b/docs/mvp-spec/06-docker-security-compliance.md
@@ -1,0 +1,3 @@
+# 6. Docker, Security & Compliance
+
+Dockerfile + compose snippet, security controls (no key leakage, rate limiting), compliance anchors referencing AIP / CASA, disclaimer text.

--- a/docs/mvp-spec/07-scenarios-and-tests.md
+++ b/docs/mvp-spec/07-scenarios-and-tests.md
@@ -1,0 +1,3 @@
+# 7. Scenarios & Test Cases
+
+Scenario JSON DSL example plus sample tests (missing QNH, wrong runway, persona noise, handoff gating, timeout path).

--- a/docs/mvp-spec/08-improvements-performance-risks.md
+++ b/docs/mvp-spec/08-improvements-performance-risks.md
@@ -1,0 +1,3 @@
+# 8. Improvements, Performance & Risks
+
+MVP-friendly enhancements, performance tuning notes (streaming frequency, temperature & seed settings, TTS caching), risk controls (hallucinated clearances, unsafe guidance mitigation, legal accuracy boundaries).

--- a/docs/mvp-spec/SEGMENT-OVERVIEW.md
+++ b/docs/mvp-spec/SEGMENT-OVERVIEW.md
@@ -1,0 +1,3 @@
+# MVP Spec Segment Overview
+
+This folder houses the split parts of the original comprehensive MVP specification: docs (this), backend, and frontend implementation notes.

--- a/docs/prompts/README.md
+++ b/docs/prompts/README.md
@@ -1,0 +1,3 @@
+# Prompt Packs
+
+This directory contains system and model prompts for Instructor, ATC, STT bias, and TTS steering.

--- a/docs/prompts/atc.md
+++ b/docs/prompts/atc.md
@@ -1,0 +1,3 @@
+# ATC System Prompt
+
+Excerpt referencing dynamic state insertion and schema.

--- a/docs/prompts/instructor.md
+++ b/docs/prompts/instructor.md
@@ -1,0 +1,8 @@
+# Instructor System Prompt
+
+(Structured Outputs variant excerpt from spec.)
+
+```
+You are "Instructor". Task: score and coach pilot radio calls per AIP Australia.
+... (see full spec for scoring rules and schema) ...
+```

--- a/docs/prompts/shared-system.md
+++ b/docs/prompts/shared-system.md
@@ -1,0 +1,10 @@
+# Shared System Preamble
+
+```
+Role: Simulator kernel. You must follow AIP Australia phraseology and readback rules.
+Use ICAO standard terms with Australian variants. Avoid US-only slang.
+Units: NM for distance, ft for altitude, kt for speed, hPa for QNH.
+Never invent frequencies; use provided airport data only.
+Keep transmissions ≤ 8 s. Pause between items.
+If asked to teach, defer to Instructor bot.
+```

--- a/docs/prompts/stt-bias.md
+++ b/docs/prompts/stt-bias.md
@@ -1,0 +1,5 @@
+# STT Bias Prompt Example
+
+```
+Use Australian aviation terms. Airport identifiers YSSY, YBBN, YMML, YPAD. Words: QNH, runway, squawk, kilo, papa, hPa. Callsign format VH-XXX.
+```

--- a/docs/prompts/tts-style.md
+++ b/docs/prompts/tts-style.md
@@ -1,0 +1,3 @@
+# TTS Style Examples
+
+Sample style strings for tonal steering.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,8 @@
+# Frontend Segment (Blazor Server UI)
+
+Razor pages/components for:
+- Scenario selection
+- Live simulation (mic capture, transcript, ATC panel, retry bar, score strip)
+- Debrief (timeline, audio playback, metrics)
+
+Leverages SignalR through shared hub. Audio capture via JS interop (WebAudio API).


### PR DESCRIPTION
This PR sets up the repository structure and documentation for the MVP:

- Created docs/ with segmented spec (scope, architecture, API, turn loop, prompts, scoring, etc.)
- Added backend/frontend segmentation readmes
- Added service interface placeholders (to be moved into proper projects next)
- Added Copilot guidance (`.github/COPILOT_INSTRUCTIONS.md` + project context files)
- Added roadmap, testing strategy, security notes, latency targets, rate limiting, repair strategy
- Added contrib, issue/PR templates
- Added placeholder schema and seed notes
- Added architecture breakdown (events, sequence, boundaries)

Next steps (not in this PR):
- Scaffold Blazor Server solution + EF Core context
- Implement STT controller + OpenAI integration
- Wire SignalR hub and sample events

Note: CI workflow not added yet due to path creation issue; will follow up in separate PR.
